### PR TITLE
Fix import path for address schema in user creation server

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "api",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "",
 	"main": "index.js",
 	"type": "module",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -5,8 +5,7 @@ import router from '@/app/module_routes/module_routes';
 import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import express, { type Application, type Request, type Response } from 'express';
-// import notFound from './app/middlewares/not_found.js';
-// import router from './app/module_routes/module_routes.js';
+
 const app: Application = express();
 
 app.use(express.json());

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@amar-haat/schemas",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"type": "module",
 	"description": "",
 	"scripts": {

--- a/packages/schemas/src/user/server/user.create.server.schema.ts
+++ b/packages/schemas/src/user/server/user.create.server.schema.ts
@@ -1,6 +1,5 @@
-import { AddressSchema } from '@shared/schemas/common/address.schema.js';
 import { z } from 'zod';
-import { PasswordSchema, SellerStatusEnum } from '../../common';
+import { AddressSchema, PasswordSchema, SellerStatusEnum } from '../../common';
 import { BaseUserSchema } from '../base/user.base.schema';
 
 export const CreateUserServerSchema = BaseUserSchema.extend({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
     devDependencies:
       '@amar-haat/config':
         specifier: workspace:*


### PR DESCRIPTION
This pull request includes minor updates across multiple packages, focusing on version bumps and a small import fix. No major functionality changes are introduced.

Version updates:

* Bumped the version in `apps/api/package.json` from `0.0.1` to `0.0.2`.
* Bumped the version in `packages/schemas/package.json` from `0.0.1` to `0.0.2`.

Code maintenance:

* Fixed the import of `AddressSchema` in `user.create.server.schema.ts` to use the correct path from `../../common`.
* Cleaned up commented-out imports in `apps/api/src/app.ts` related to routes and middleware.…eate server and remove commented path in app.ts file in api